### PR TITLE
fix: Renamed some parameters

### DIFF
--- a/src/Helix/EventSub/Conditions/ChannelRaidCondition.php
+++ b/src/Helix/EventSub/Conditions/ChannelRaidCondition.php
@@ -36,7 +36,7 @@ class ChannelRaidCondition extends AbstractCondition
     /**
      * @return string
      */
-    public function getFromBroadcasterUserId(): string
+    public function getFromBroadcasterUserId(): ?string
     {
         return $this->fromBroadcasterUserId;
     }
@@ -44,7 +44,7 @@ class ChannelRaidCondition extends AbstractCondition
     /**
      * @return string
      */
-    public function getToBroadcasterUserId(): string
+    public function getToBroadcasterUserId(): ?string
     {
         return $this->toBroadcasterUserId;
     }

--- a/src/Helix/EventSub/Entity/BitsVoting.php
+++ b/src/Helix/EventSub/Entity/BitsVoting.php
@@ -7,7 +7,7 @@ class BitsVoting
     /**
      * @var bool
      */
-    protected $enabled;
+    protected $isEnabled;
 
     /**
      * @var int
@@ -17,19 +17,19 @@ class BitsVoting
     /**
      * @return bool
      */
-    public function isEnabled(): bool
+    public function isIsEnabled(): bool
     {
-        return $this->enabled;
+        return $this->isEnabled;
     }
 
     /**
-     * @param bool $enabled
+     * @param bool $isEnabled
      *
      * @return $this
      */
-    public function setEnabled(bool $enabled): self
+    public function setIsEnabled(bool $isEnabled): self
     {
-        $this->enabled = $enabled;
+        $this->isEnabled = $isEnabled;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/ChannelPointsVoting.php
+++ b/src/Helix/EventSub/Entity/ChannelPointsVoting.php
@@ -7,7 +7,7 @@ class ChannelPointsVoting
     /**
      * @var bool
      */
-    protected $enabled;
+    protected $isEnabled;
 
     /**
      * @var int
@@ -17,19 +17,19 @@ class ChannelPointsVoting
     /**
      * @return bool
      */
-    public function isEnabled(): bool
+    public function isIsEnabled(): bool
     {
-        return $this->enabled;
+        return $this->isEnabled;
     }
 
     /**
-     * @param bool $enabled
+     * @param bool $isEnabled
      *
      * @return $this
      */
-    public function setEnabled(bool $enabled): self
+    public function setIsEnabled(bool $isEnabled): self
     {
-        $this->enabled = $enabled;
+        $this->isEnabled = $isEnabled;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/Events/ChannelBanEvent.php
+++ b/src/Helix/EventSub/Entity/Events/ChannelBanEvent.php
@@ -21,7 +21,7 @@ class ChannelBanEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $permanent;
+    protected $isPermanent;
 
     /**
      * @return string
@@ -66,19 +66,19 @@ class ChannelBanEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isPermanent(): bool
+    public function isIsPermanent(): bool
     {
-        return $this->permanent;
+        return $this->isPermanent;
     }
 
     /**
-     * @param bool $permanent
+     * @param bool $isPermanent
      *
      * @return ChannelBanEvent
      */
-    public function setPermanent(bool $permanent): ChannelBanEvent
+    public function setIsPermanent(bool $isPermanent): ChannelBanEvent
     {
-        $this->permanent = $permanent;
+        $this->isPermanent = $isPermanent;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/Events/ChannelCheerEvent.php
+++ b/src/Helix/EventSub/Entity/Events/ChannelCheerEvent.php
@@ -10,7 +10,7 @@ class ChannelCheerEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $anonymous;
+    protected $isAnonymous;
 
     /**
      * @var string
@@ -25,19 +25,19 @@ class ChannelCheerEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isAnonymous(): bool
+    public function isIsAnonymous(): bool
     {
-        return $this->anonymous;
+        return $this->isAnonymous;
     }
 
     /**
-     * @param bool $anonymous
+     * @param bool $isAnonymous
      *
      * @return ChannelCheerEvent
      */
-    public function setAnonymous(bool $anonymous): ChannelCheerEvent
+    public function setIsAnonymous(bool $isAnonymous): ChannelCheerEvent
     {
-        $this->anonymous = $anonymous;
+        $this->isAnonymous = $isAnonymous;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/Events/ChannelGoalBeginEvent.php
+++ b/src/Helix/EventSub/Entity/Events/ChannelGoalBeginEvent.php
@@ -24,7 +24,7 @@ class ChannelGoalBeginEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $achieved;
+    protected $isAchieved;
 
     /**
      * @var int
@@ -109,19 +109,19 @@ class ChannelGoalBeginEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isAchieved(): bool
+    public function isIsAchieved(): bool
     {
-        return $this->achieved;
+        return $this->isAchieved;
     }
 
     /**
-     * @param bool $achieved
+     * @param bool $isAchieved
      *
      * @return $this
      */
-    public function setAchieved(bool $achieved): self
+    public function setIsAchieved(bool $isAchieved): self
     {
-        $this->achieved = $achieved;
+        $this->isAchieved = $isAchieved;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/Events/ChannelPointsCustomRewardAddEvent.php
+++ b/src/Helix/EventSub/Entity/Events/ChannelPointsCustomRewardAddEvent.php
@@ -19,17 +19,17 @@ class ChannelPointsCustomRewardAddEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $enabled;
+    protected $isEnabled;
 
     /**
      * @var bool
      */
-    protected $paused;
+    protected $isPaused;
 
     /**
      * @var bool
      */
-    protected $inStock;
+    protected $isInStock;
 
     /**
      * @var string
@@ -49,7 +49,7 @@ class ChannelPointsCustomRewardAddEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $userInputRequired;
+    protected $isUserInputRequired;
 
     /**
      * @var bool
@@ -119,19 +119,19 @@ class ChannelPointsCustomRewardAddEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isEnabled(): bool
+    public function isIsEnabled(): bool
     {
-        return $this->enabled;
+        return $this->isEnabled;
     }
 
     /**
-     * @param bool $enabled
+     * @param bool $isEnabled
      *
      * @return $this
      */
-    public function setEnabled(bool $enabled): self
+    public function setIsEnabled(bool $isEnabled): self
     {
-        $this->enabled = $enabled;
+        $this->isEnabled = $isEnabled;
 
         return $this;
     }
@@ -139,19 +139,19 @@ class ChannelPointsCustomRewardAddEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isPaused(): bool
+    public function isIsPaused(): bool
     {
-        return $this->paused;
+        return $this->isPaused;
     }
 
     /**
-     * @param bool $paused
+     * @param bool $isPaused
      *
      * @return $this
      */
-    public function setPaused(bool $paused): self
+    public function setIsPaused(bool $isPaused): self
     {
-        $this->paused = $paused;
+        $this->isPaused = $isPaused;
 
         return $this;
     }
@@ -159,19 +159,19 @@ class ChannelPointsCustomRewardAddEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isInStock(): bool
+    public function isIsInStock(): bool
     {
-        return $this->inStock;
+        return $this->isInStock;
     }
 
     /**
-     * @param bool $inStock
+     * @param bool $isInStock
      *
      * @return $this
      */
-    public function setInStock(bool $inStock): self
+    public function setIsInStock(bool $isInStock): self
     {
-        $this->inStock = $inStock;
+        $this->isInStock = $isInStock;
 
         return $this;
     }
@@ -239,19 +239,19 @@ class ChannelPointsCustomRewardAddEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isUserInputRequired(): bool
+    public function isIsUserInputRequired(): bool
     {
-        return $this->userInputRequired;
+        return $this->isUserInputRequired;
     }
 
     /**
-     * @param bool $userInputRequired
+     * @param bool $isUserInputRequired
      *
      * @return $this
      */
-    public function setUserInputRequired(bool $userInputRequired): self
+    public function setIsUserInputRequired(bool $isUserInputRequired): self
     {
-        $this->userInputRequired = $userInputRequired;
+        $this->isUserInputRequired = $isUserInputRequired;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/Events/ChannelSubscribeEvent.php
+++ b/src/Helix/EventSub/Entity/Events/ChannelSubscribeEvent.php
@@ -15,7 +15,7 @@ class ChannelSubscribeEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $gift;
+    protected $isGift;
 
     /**
      * @return string
@@ -40,19 +40,19 @@ class ChannelSubscribeEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isGift(): bool
+    public function isIsGift(): bool
     {
-        return $this->gift;
+        return $this->isGift;
     }
 
     /**
-     * @param bool $gift
+     * @param bool $isGift
      *
      * @return ChannelSubscribeEvent
      */
-    public function setGift(bool $gift): ChannelSubscribeEvent
+    public function setIsGift(bool $isGift): ChannelSubscribeEvent
     {
-        $this->gift = $gift;
+        $this->isGift = $isGift;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/Events/ChannelSubscriptionGiftEvent.php
+++ b/src/Helix/EventSub/Entity/Events/ChannelSubscriptionGiftEvent.php
@@ -27,7 +27,7 @@ class ChannelSubscriptionGiftEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $anonymous;
+    protected $isAnonymous;
 
     /**
      * @return int
@@ -92,19 +92,19 @@ class ChannelSubscriptionGiftEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isAnonymous(): bool
+    public function isIsAnonymous(): bool
     {
-        return $this->anonymous;
+        return $this->isAnonymous;
     }
 
     /**
-     * @param bool $anonymous
+     * @param bool $isAnonymous
      *
      * @return $this
      */
-    public function setAnonymous(bool $anonymous): self
+    public function setIsAnonymous(bool $isAnonymous): self
     {
-        $this->anonymous = $anonymous;
+        $this->isAnonymous = $isAnonymous;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/Events/ChannelUpdateEvent.php
+++ b/src/Helix/EventSub/Entity/Events/ChannelUpdateEvent.php
@@ -29,7 +29,7 @@ class ChannelUpdateEvent extends AbstractEvent
     /**
      * @var bool
      */
-    protected $mature;
+    protected $isMature;
 
     /**
      * @return string
@@ -114,19 +114,19 @@ class ChannelUpdateEvent extends AbstractEvent
     /**
      * @return bool
      */
-    public function isMature(): bool
+    public function isIsMature(): bool
     {
-        return $this->mature;
+        return $this->isMature;
     }
 
     /**
-     * @param bool $mature
+     * @param bool $isMature
      *
      * @return ChannelUpdateEvent
      */
-    public function setMature(bool $mature): ChannelUpdateEvent
+    public function setIsMature(bool $isMature): ChannelUpdateEvent
     {
-        $this->mature = $mature;
+        $this->isMature = $isMature;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/GlobalCooldown.php
+++ b/src/Helix/EventSub/Entity/GlobalCooldown.php
@@ -7,7 +7,7 @@ class GlobalCooldown
     /**
      * @var bool
      */
-    protected $enabled;
+    protected $isEnabled;
 
     /**
      * @var int
@@ -17,19 +17,19 @@ class GlobalCooldown
     /**
      * @return bool
      */
-    public function isEnabled(): bool
+    public function isIsEnabled(): bool
     {
-        return $this->enabled;
+        return $this->isEnabled;
     }
 
     /**
-     * @param bool $enabled
+     * @param bool $isEnabled
      *
      * @return $this
      */
-    public function setEnabled(bool $enabled): self
+    public function setIsEnabled(bool $isEnabled): self
     {
-        $this->enabled = $enabled;
+        $this->isEnabled = $isEnabled;
 
         return $this;
     }

--- a/src/Helix/EventSub/Entity/MaxPerStream.php
+++ b/src/Helix/EventSub/Entity/MaxPerStream.php
@@ -7,7 +7,7 @@ class MaxPerStream
     /**
      * @var bool
      */
-    protected $enabled;
+    protected $isEnabled;
 
     /**
      * @var int
@@ -17,19 +17,19 @@ class MaxPerStream
     /**
      * @return bool
      */
-    public function isEnabled(): bool
+    public function isIsEnabled(): bool
     {
-        return $this->enabled;
+        return $this->isEnabled;
     }
 
     /**
-     * @param bool $enabled
+     * @param bool $isEnabled
      *
      * @return $this
      */
-    public function setEnabled(bool $enabled): self
+    public function setIsEnabled(bool $isEnabled): self
     {
-        $this->enabled = $enabled;
+        $this->isEnabled = $isEnabled;
 
         return $this;
     }


### PR DESCRIPTION
- Some parameters had to be renamed because of the "is_" prefix that was missing. Could've been fixed by the serializer but it is how it is now